### PR TITLE
Refresh: RealtimeSTT live + Senko diarization (Droid-assisted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple, fast terminal transcriber with two commands:
 
 ---
 
-## 1 · Features
+## 1&nbsp;· Features
 - **Live mic transcription in terminal**
 - **Default engine**: RealtimeSTT (voice-activity-detection, wake-word ready, low latency)  
   **Fallback**: legacy SpeechRecognition + faster-whisper
@@ -20,7 +20,7 @@ A simple, fast terminal transcriber with two commands:
 
 ---
 
-## 2 · Requirements
+## 2&nbsp;· Requirements
 - Python **3.9+**
 - **PortAudio** runtime for microphone access  
   • macOS: `brew install portaudio` then `pip install pyaudio`  
@@ -28,7 +28,7 @@ A simple, fast terminal transcriber with two commands:
 
 ---
 
-## 3 · Install
+## 3&nbsp;· Install
 
 ```bash
 git clone https://github.com/tristan-mcinnis/Realtime-Whisper-Console-Transcriber
@@ -51,13 +51,18 @@ uv pip install "git+https://github.com/narcotic-sh/senko.git"
 
 ---
 
-## 4 · Usage
+## 4&nbsp;· Usage
 
 ### Live (default engine: RealtimeSTT)
 ```bash
 python transcribe.py live --language en
 ```
 If RealtimeSTT is not present, the script transparently switches to the legacy engine.
+
+```bash
+# Minimal console output (no Rich panels)
+python transcribe.py live --language en --plain
+```
 
 ### Live with legacy engine
 ```bash
@@ -74,16 +79,16 @@ python transcribe.py diarize path/to/audio.wav \
     --json-out diarization.json
 ```
 Prints speaker segments and (optionally) writes merged segments to JSON.  
-Prepare audio with `ffmpeg -i input.mp3 -ac 1 -ar 16000 -sample_fmt s16 output.wav`.
+Prepare audio with `ffmpeg -i input.mp3 -ac 1 -ar 16000 -sample_fmt s16 output.wav`  (if you pass a non-WAV file, the tool will attempt this conversion automatically when **ffmpeg** is available).
 
 ---
 
-## 5 · Notes
+## 5&nbsp;· Notes
 - **GPU** acceleration is optional. RealtimeSTT supports CUDA; faster-whisper runs on CPU by default.
 - On **Windows**, multiprocessing requirements are handled inside the script (`if __name__ == "__main__":` guard).
 - Disable automatic saving of transcripts via `--no-save` flag on `live`.
 
 ---
 
-## 6 · License
+## 6&nbsp;· License
 This project remains under the existing LICENSE contained in the repository.

--- a/README.md
+++ b/README.md
@@ -1,70 +1,89 @@
-# Whisper Console Transcriber
+# Realtime Whisper Console Transcriber (Refreshed)
 
-A real-time speech-to-text transcriber using the Whisper model, designed for efficiency and ease of use in the console. This tool leverages the faster_whisper library and Rich to provide a seamless user experience for transcribing audio inputs on the fly.
+A simple, fast terminal transcriber with two commands:
 
-## Background
+* `live` – real-time microphone transcription  
+* `diarize` – offline speaker diarization (optional)
 
-Whisper is a state-of-the-art model for automatic speech recognition (ASR). This project utilizes the Whisper model and provides a practical interface for capturing live audio input, transcribing it, and displaying the results in real time. It's designed to be flexible, allowing the user to choose the language of transcription and offering a buffer system to handle continuous speech.
+`live` defaults to the low-latency RealtimeSTT engine and automatically falls back to a legacy SpeechRecognition + faster-whisper path if RealtimeSTT is not installed.  
+`diarize` uses the Senko library for very fast speaker diarization when available.
 
-## Features
+---
 
--  Real-time speech-to-text using Whisper model
--  Support for multiple languages
--  Console-based application with rich text formatting
--  Automatic ambient noise adjustment
--  Saves transcriptions to a file in the Downloads folder
+## 1 · Features
+- **Live mic transcription in terminal**
+- **Default engine**: RealtimeSTT (voice-activity-detection, wake-word ready, low latency)  
+  **Fallback**: legacy SpeechRecognition + faster-whisper
+- **Optional offline speaker diarization** via Senko (`diarize` command)
+- Saves transcripts to `~/Downloads/` automatically (disable with `--no-save`)
+- Tested on **macOS** and **Windows**
 
-## Installation
+---
 
-To install and run this project, follow these steps:
+## 2 · Requirements
+- Python **3.9+**
+- **PortAudio** runtime for microphone access  
+  • macOS: `brew install portaudio` then `pip install pyaudio`  
+  • Windows: `pip install pipwin && pipwin install pyaudio`
 
-1. **Clone the repo:**
-    ```sh
-    git clone https://github.com/nexuslux/Realtime-Whisper-Console-Transcriber
-    cd WhisperConsoleTranscriber
-    ```
+---
 
-2. **Set up a virtual environment (optional but recommended):**
-    ```sh
-    python -m venv venv
-    source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
-    ```
+## 3 · Install
 
-3. **Install required dependencies:**
-    ```sh
-    pip install faster_whisper speechrecognition rich
-    ```
+```bash
+git clone https://github.com/tristan-mcinnis/Realtime-Whisper-Console-Transcriber
+cd Realtime-Whisper-Console-Transcriber
 
-## How to Run
+# create & activate virtual env  (Windows: .venv\Scripts\activate)
+python -m venv .venv && source .venv/bin/activate
 
-1. **Run the script:**
-    ```sh
-    python script_name.py
-    ```
+# core dependencies
+pip install -r requirements.txt
 
-2. **Follow the prompts:**
-    - After running the script, you will be prompted to enter the language code (e.g., 'en' for English, 'zh' for Chinese, 'es' for Spanish).
-    - The application will then adjust for ambient noise and start capturing audio.
+# Optional – best live experience
+pip install RealtimeSTT
 
-3. **Start speaking or playing audio:**
-    - Once you start speaking, the application will transcribe your speech in real time.
-    - Transcriptions are buffered and displayed in chunks.
+# Optional – diarization (Senko)
+# mac / CPU:
+uv pip install "git+https://github.com/narcotic-sh/senko.git"
+# NVIDIA GPU: see Senko README for the correct extras
+```
 
-4. **Stop listening:**
-    - Press `CTRL + C` to stop the transcription process.
-    - The transcriptions will automatically be saved to a text file in your Downloads folder.
+---
 
-## Example
+## 4 · Usage
 
-```sh
-python transcribe.py
- ```
+### Live (default engine: RealtimeSTT)
+```bash
+python transcribe.py live --language en
+```
+If RealtimeSTT is not present, the script transparently switches to the legacy engine.
 
-After this you will be asked to enter the main language.
-	•	Enter the language code: en
-	•	Start speaking. The application will display transcribed text in the console.
-	•	End the session with CTRL + C. The output will be saved to a text file in the Downloads folder.
-Customization
-You can customize the following parameters in the script:
-	•	buffer_size: Number of segments to buffer before displaying the transcription.
-	•	language_code: Set your preferred default language code for transcription.
+### Live with legacy engine
+```bash
+python transcribe.py live --engine legacy \
+    --language en \
+    --buffer-size 2 \
+    --phrase-time-limit 3
+```
+
+### Diarize a WAV file (16 kHz mono 16-bit)
+```bash
+python transcribe.py diarize path/to/audio.wav \
+    --device auto \
+    --json-out diarization.json
+```
+Prints speaker segments and (optionally) writes merged segments to JSON.  
+Prepare audio with `ffmpeg -i input.mp3 -ac 1 -ar 16000 -sample_fmt s16 output.wav`.
+
+---
+
+## 5 · Notes
+- **GPU** acceleration is optional. RealtimeSTT supports CUDA; faster-whisper runs on CPU by default.
+- On **Windows**, multiprocessing requirements are handled inside the script (`if __name__ == "__main__":` guard).
+- Disable automatic saving of transcripts via `--no-save` flag on `live`.
+
+---
+
+## 6 · License
+This project remains under the existing LICENSE contained in the repository.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+rich
+faster-whisper
+SpeechRecognition
+pyaudio

--- a/transcribe.py
+++ b/transcribe.py
@@ -6,6 +6,9 @@ import json
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, List
+import shutil
+import subprocess
+import tempfile
 
 # Set the environment variable to allow duplicate OpenMP runtime initialization
 os.environ['KMP_DUPLICATE_LIB_OK'] = 'TRUE'
@@ -32,7 +35,43 @@ def fmt_ts(seconds: float) -> str:
     minutes, seconds = divmod(remainder, 60)
     return f"{int(hours):02d}:{int(minutes):02d}:{seconds:.3f}"
 
-def live_realtimestt(language: str, model: str, save: bool) -> None:
+def ensure_wav_16k_mono(input_path: str) -> str:
+    """
+    Ensure the provided file is a 16 kHz mono 16-bit WAV.
+    If the file is already a .wav we optimistically assume it is correct.
+    Otherwise we attempt conversion via ffmpeg, writing to a temp file.
+    """
+    # fast-path for wav
+    if input_path.lower().endswith('.wav'):
+        return input_path
+
+    ff = shutil.which('ffmpeg')
+    if not ff:
+        raise RuntimeError(
+            "Non-WAV file provided and ffmpeg not found. "
+            "Please convert the audio to 16 kHz mono 16-bit WAV or install ffmpeg."
+        )
+
+    tmp_out = os.path.join(
+        tempfile.gettempdir(), f"diarize-{int(time.time())}.wav"
+    )
+    cmd = [
+        ff,
+        '-y',
+        '-i', input_path,
+        '-ac', '1',
+        '-ar', '16000',
+        '-sample_fmt', 's16',
+        tmp_out,
+    ]
+    res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg conversion failed: {res.stderr.decode(errors='ignore')[:400]}"
+        )
+    return tmp_out
+
+def live_realtimestt(language: str, model: str, save: bool, plain: bool = False) -> None:
     try:
         from RealtimeSTT import AudioToTextRecorder
     except Exception:
@@ -53,7 +92,10 @@ def live_realtimestt(language: str, model: str, save: bool) -> None:
             language=language or "auto",
             enable_realtime_transcription=False,
         ) as recorder:
-            console.print(Panel("Listening… Press CTRL+C to stop", border_style="green", title="LIVE · RealtimeSTT"))
+            if plain:
+                console.print("Listening… Press CTRL+C to stop")
+            else:
+                console.print(Panel("Listening… Press CTRL+C to stop", border_style="green", title="LIVE · RealtimeSTT"))
             recorder.listen()
             while True:
                 phrase = recorder.text()  # blocks until a phrase is finalized by VAD
@@ -71,7 +113,7 @@ def live_realtimestt(language: str, model: str, save: bool) -> None:
         if save and captured:
             save_log_to_file(captured, prefix="live")
 
-def live_legacy(language: str, model: str, buffer_size: int, phrase_time_limit: int, save: bool) -> None:
+def live_legacy(language: str, model: str, buffer_size: int, phrase_time_limit: int, save: bool, plain: bool = False) -> None:
     try:
         import speech_recognition as sr
     except Exception as e:
@@ -118,9 +160,15 @@ def live_legacy(language: str, model: str, buffer_size: int, phrase_time_limit: 
     # ambient noise adjust and background listen
     try:
         with sr.Microphone() as source:
-            console.print(Panel(f"Adjusting for ambient noise… (Language: {language})", border_style="blue", title="INIT"))
+            if plain:
+                console.print(f"Adjusting for ambient noise… (Language: {language})")
+            else:
+                console.print(Panel(f"Adjusting for ambient noise… (Language: {language})", border_style="blue", title="INIT"))
             r.adjust_for_ambient_noise(source, duration=2)
-        console.print(Panel("Start speaking. Press CTRL+C to stop", border_style="green", title="LIVE · Legacy"))
+        if plain:
+            console.print("Start speaking. Press CTRL+C to stop")
+        else:
+            console.print(Panel("Start speaking. Press CTRL+C to stop", border_style="green", title="LIVE · Legacy"))
         stop_listening = r.listen_in_background(sr.Microphone(), callback, phrase_time_limit=phrase_time_limit)
         while True:
             time.sleep(0.5)
@@ -151,9 +199,10 @@ def diarize_file(audio_path: str, device: str = 'auto', json_out: Optional[str] 
         ))
         return
 
+    src = ensure_wav_16k_mono(audio_path)
     try:
         diarizer = senko.Diarizer(torch_device=device, warmup=True, quiet=True)
-        result = diarizer.diarize(audio_path, generate_colors=False)
+        result = diarizer.diarize(src, generate_colors=False)
         if result is None:
             console.print(Panel("No speakers detected.", border_style="yellow", title="DIARIZATION"))
             return
@@ -170,6 +219,13 @@ def diarize_file(audio_path: str, device: str = 'auto', json_out: Optional[str] 
             console.print(Panel(f"Saved JSON: {json_out}", border_style="green", title="OUTPUT"))
     except Exception as e:
         console.print(Panel(f"Diarization error: {e}", border_style="red", title="ERROR"))
+    finally:
+        # remove temp converted file if we created one
+        try:
+            if src != audio_path and os.path.exists(src):
+                os.remove(src)
+        except Exception:
+            pass
 
 def main():
     parser = argparse.ArgumentParser(description="Console transcriber: realtime (live) and diarization (offline)")
@@ -182,6 +238,7 @@ def main():
     p_live.add_argument('--buffer-size', type=int, default=2, help='Legacy engine: number of segments to buffer before printing')
     p_live.add_argument('--phrase-time-limit', type=int, default=3, help='Legacy engine: seconds per phrase chunk')
     p_live.add_argument('--no-save', action='store_true', help='Do not save transcript to Downloads at exit')
+    p_live.add_argument('--plain', action='store_true', help='Plain output (no rich panels)')
 
     p_diar = sub.add_parser('diarize', help='Offline speaker diarization for an audio file (WAV 16kHz mono)')
     p_diar.add_argument('audio_path', help='Path to WAV file (16kHz mono 16-bit)')
@@ -194,12 +251,12 @@ def main():
         save = not args.no_save
         if args.engine == 'rstt':
             try:
-                live_realtimestt(args.language, args.model, save)
+                live_realtimestt(args.language, args.model, save, args.plain)
             except ImportError as e:
                 console.print(Panel(str(e) + "\nFalling back to legacy engine…", border_style="yellow", title="FALLBACK"))
-                live_legacy(args.language, args.model, args.buffer_size, args.phrase_time_limit, save)
+                live_legacy(args.language, args.model, args.buffer_size, args.phrase_time_limit, save, args.plain)
         else:
-            live_legacy(args.language, args.model, args.buffer_size, args.phrase_time_limit, save)
+            live_legacy(args.language, args.model, args.buffer_size, args.phrase_time_limit, save, args.plain)
     elif args.cmd == 'diarize':
         diarize_file(args.audio_path, device=args.device, json_out=args.json_out)
 

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,80 +1,207 @@
 import os
+import sys
 import time
+import argparse
+import json
 from datetime import datetime
 from pathlib import Path
+from typing import Optional, List
 
 # Set the environment variable to allow duplicate OpenMP runtime initialization
 os.environ['KMP_DUPLICATE_LIB_OK'] = 'TRUE'
 
-from faster_whisper import WhisperModel
-import speech_recognition as sr
 from rich.console import Console
 from rich.panel import Panel
 
 # Initialize Rich Console
 console = Console()
 
-# Initialize Whisper model
-num_cores = os.cpu_count()
-whisper_model = WhisperModel('base', device='cpu', compute_type='int8', cpu_threads=num_cores // 2, num_workers=num_cores // 2)
-
-r = sr.Recognizer()
-
-buffer = []
-buffer_size = 2  # Number of segments to buffer before printing
-
-# To capture console output
-captured_output = []
-
-def log(message):
-    if isinstance(message, Panel):
-        console.print(message)
-    else:
-        console.print(message)
-        captured_output.append(message)
-
-def wav_to_text(audio_path, language):
-    segments, _ = whisper_model.transcribe(audio_path, language=language)
-    text = ''.join(segment.text for segment in segments)
-    return text
-
-def callback(recognizer, audio, language):
-    global buffer
-    prompt_audio_path = 'prompt.wav'
-    with open(prompt_audio_path, 'wb') as f:
-        f.write(audio.get_wav_data())
-    prompt_text = wav_to_text(prompt_audio_path, language)
-    buffer.append(prompt_text)
-    if len(buffer) >= buffer_size:
-        combined_text = ' '.join(buffer)
-        log(combined_text)
-        buffer = []
-
-def save_log_to_file(text):
+def save_log_to_file(lines: List[str], prefix: str = "transcript") -> str:
+    """Writes joined lines with newlines to ~/Downloads/{prefix}-{YYYYMMDD-HHMMSS}.txt"""
     downloads_folder = str(Path.home() / "Downloads")
-    filename = datetime.now().strftime("%Y%m%d-%H%M%S") + ".txt"
+    filename = f"{prefix}-{datetime.now().strftime('%Y%m%d-%H%M%S')}.txt"
     file_path = os.path.join(downloads_folder, filename)
-    with open(file_path, 'w') as f:
-        f.write(text)
-    log(Panel(f"Transcription saved to {file_path}", border_style="bold green", title="LOG"))
+    with open(file_path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(lines))
+    console.print(Panel(f"Transcript saved to {file_path}", border_style="green", title="OUTPUT"))
+    return file_path
 
-def start_listening(language='en'):
-    log(Panel(f"Adjusting for ambient noise... (Language: {language})", border_style="blue1", title="ACTION"))
-    with sr.Microphone() as source:
-        r.adjust_for_ambient_noise(source, duration=2)
-    log(Panel("Start speaking / start audio. Press 'CTRL + C' to exit", border_style="green1", title="ACTION"))
-    stop_listening = r.listen_in_background(sr.Microphone(), lambda recognizer, audio: callback(recognizer, audio, language), phrase_time_limit=3)
+def fmt_ts(seconds: float) -> str:
+    """Format seconds to HH:MM:SS.mmm"""
+    hours, remainder = divmod(seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{int(hours):02d}:{int(minutes):02d}:{seconds:.3f}"
+
+def live_realtimestt(language: str, model: str, save: bool) -> None:
     try:
+        from RealtimeSTT import AudioToTextRecorder
+    except Exception:
+        raise ImportError("RealtimeSTT not installed. Install with: pip install RealtimeSTT")
+
+    captured: List[str] = []
+
+    def append_and_print(text: str):
+        if not text:
+            return
+        console.print(text)
+        captured.append(text)
+
+    # Use VAD-driven segments; print final phrases for stability and simplicity
+    try:
+        with AudioToTextRecorder(
+            model=model,
+            language=language or "auto",
+            enable_realtime_transcription=False,
+        ) as recorder:
+            console.print(Panel("Listening… Press CTRL+C to stop", border_style="green", title="LIVE · RealtimeSTT"))
+            recorder.listen()
+            while True:
+                phrase = recorder.text()  # blocks until a phrase is finalized by VAD
+                append_and_print(phrase)
+    except KeyboardInterrupt:
+        pass
+    except Exception as e:
+        console.print(Panel(f"RealtimeSTT error: {e}", border_style="red", title="ERROR"))
+    finally:
+        # Best-effort shutdown if context wasn't used or was interrupted
+        try:
+            recorder.shutdown()  # type: ignore[name-defined]
+        except Exception:
+            pass
+        if save and captured:
+            save_log_to_file(captured, prefix="live")
+
+def live_legacy(language: str, model: str, buffer_size: int, phrase_time_limit: int, save: bool) -> None:
+    try:
+        import speech_recognition as sr
+    except Exception as e:
+        console.print(Panel("speech_recognition is required for legacy mode. Install with: pip install SpeechRecognition", border_style="red", title="MISSING DEP"))
+        return
+    try:
+        from faster_whisper import WhisperModel
+    except Exception:
+        console.print(Panel("faster-whisper is required for legacy mode. Install with: pip install faster-whisper", border_style="red", title="MISSING DEP"))
+        return
+
+    num_cores = max(1, (os.cpu_count() or 2) // 2)
+    whisper_model = WhisperModel(model, device='cpu', compute_type='int8', cpu_threads=num_cores, num_workers=num_cores)
+
+    r = sr.Recognizer()
+    buffer: List[str] = []
+    captured: List[str] = []
+
+    def wav_to_text(audio_path: str, lang: str) -> str:
+        segments, _ = whisper_model.transcribe(audio_path, language=lang)
+        return ''.join(seg.text for seg in segments)
+
+    def callback(recognizer, audio):
+        nonlocal buffer
+        tmp_path = 'prompt.wav'
+        try:
+            with open(tmp_path, 'wb') as f:
+                f.write(audio.get_wav_data())
+            text = wav_to_text(tmp_path, language)
+            buffer.append(text)
+            if len(buffer) >= buffer_size:
+                combined = ' '.join(buffer)
+                console.print(combined)
+                captured.append(combined)
+                buffer = []
+        except Exception as e:
+            console.print(Panel(f"Legacy callback error: {e}", border_style="red", title="ERROR"))
+        finally:
+            try:
+                os.remove(tmp_path)
+            except Exception:
+                pass
+
+    # ambient noise adjust and background listen
+    try:
+        with sr.Microphone() as source:
+            console.print(Panel(f"Adjusting for ambient noise… (Language: {language})", border_style="blue", title="INIT"))
+            r.adjust_for_ambient_noise(source, duration=2)
+        console.print(Panel("Start speaking. Press CTRL+C to stop", border_style="green", title="LIVE · Legacy"))
+        stop_listening = r.listen_in_background(sr.Microphone(), callback, phrase_time_limit=phrase_time_limit)
         while True:
             time.sleep(0.5)
     except KeyboardInterrupt:
-        stop_listening(wait_for_stop=False)
-        combined_text = '\n'.join(str(msg) for msg in captured_output if not isinstance(msg, Panel))
-        save_log_to_file(combined_text)
-        log(Panel("Listening stopped.", border_style="magenta3", title="ACTION"))
+        try:
+            stop_listening(wait_for_stop=False)
+        except Exception:
+            pass
+    except Exception as e:
+        console.print(Panel(f"Legacy runtime error: {e}", border_style="red", title="ERROR"))
+    finally:
+        # flush remaining buffer
+        if buffer:
+            combined = ' '.join(buffer)
+            console.print(combined)
+            captured.append(combined)
+            buffer = []
+        if save and captured:
+            save_log_to_file(captured, prefix="live")
 
-if __name__ == "__main__":
-    # Prompt user to input the language code
-    console.print(Panel("Please enter the language code (e.g., 'en' for English, 'zh' for Simplified Chinese, 'es' for Spanish):", border_style="bold purple", title="LANGUAGE SELECTION"))
-    language_code = input("Enter language code: ").strip()
-    start_listening(language_code)
+def diarize_file(audio_path: str, device: str = 'auto', json_out: Optional[str] = None) -> None:
+    try:
+        import senko
+    except Exception:
+        console.print(Panel(
+            "Senko not installed. Install (Mac/CPU):\n  uv pip install 'git+https://github.com/narcotic-sh/senko.git'\nFor NVIDIA CUDA: see Senko README",
+            border_style="yellow", title="OPTIONAL DEP"
+        ))
+        return
+
+    try:
+        diarizer = senko.Diarizer(torch_device=device, warmup=True, quiet=True)
+        result = diarizer.diarize(audio_path, generate_colors=False)
+        if result is None:
+            console.print(Panel("No speakers detected.", border_style="yellow", title="DIARIZATION"))
+            return
+        segments = result.get("merged_segments", [])
+        console.print(Panel(f"Detected {len({seg['speaker'] for seg in segments}) if segments else 0} speakers; {len(segments)} segments", border_style="green", title="DIARIZATION"))
+        for seg in segments:
+            s = seg.get('start', 0.0)
+            e = seg.get('end', 0.0)
+            spk = seg.get('speaker', '?')
+            console.print(f"[{fmt_ts(s)} – {fmt_ts(e)}] {spk}")
+        if json_out:
+            with open(json_out, 'w', encoding='utf-8') as f:
+                json.dump({"merged_segments": segments}, f, indent=2)
+            console.print(Panel(f"Saved JSON: {json_out}", border_style="green", title="OUTPUT"))
+    except Exception as e:
+        console.print(Panel(f"Diarization error: {e}", border_style="red", title="ERROR"))
+
+def main():
+    parser = argparse.ArgumentParser(description="Console transcriber: realtime (live) and diarization (offline)")
+    sub = parser.add_subparsers(dest='cmd', required=True)
+
+    p_live = sub.add_parser('live', help='Real-time microphone transcription')
+    p_live.add_argument('--engine', choices=['rstt', 'legacy'], default='rstt', help='Transcription engine (default: rstt)')
+    p_live.add_argument('--language', default='en', help='Language code (e.g., en, es, zh). Use empty for auto')
+    p_live.add_argument('--model', default='base', help='Whisper model size/name (e.g., tiny, base, small)')
+    p_live.add_argument('--buffer-size', type=int, default=2, help='Legacy engine: number of segments to buffer before printing')
+    p_live.add_argument('--phrase-time-limit', type=int, default=3, help='Legacy engine: seconds per phrase chunk')
+    p_live.add_argument('--no-save', action='store_true', help='Do not save transcript to Downloads at exit')
+
+    p_diar = sub.add_parser('diarize', help='Offline speaker diarization for an audio file (WAV 16kHz mono)')
+    p_diar.add_argument('audio_path', help='Path to WAV file (16kHz mono 16-bit)')
+    p_diar.add_argument('--device', choices=['auto', 'cuda', 'mps', 'cpu'], default='auto', help='Torch device for Senko (default: auto)')
+    p_diar.add_argument('--json-out', default=None, help='Optional path to save merged segments JSON')
+
+    args = parser.parse_args()
+
+    if args.cmd == 'live':
+        save = not args.no_save
+        if args.engine == 'rstt':
+            try:
+                live_realtimestt(args.language, args.model, save)
+            except ImportError as e:
+                console.print(Panel(str(e) + "\nFalling back to legacy engine…", border_style="yellow", title="FALLBACK"))
+                live_legacy(args.language, args.model, args.buffer_size, args.phrase_time_limit, save)
+        else:
+            live_legacy(args.language, args.model, args.buffer_size, args.phrase_time_limit, save)
+    elif args.cmd == 'diarize':
+        diarize_file(args.audio_path, device=args.device, json_out=args.json_out)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR refreshes the console transcriber with a simple, robust terminal UX and modern realtime capabilities.

Summary
- New CLI in transcribe.py with two subcommands:
  - live: real-time mic transcription
    - default engine: RealtimeSTT (VAD-driven, low latency, robust phrase-level outputs)
    - fallback: legacy SpeechRecognition + faster-whisper if RealtimeSTT is missing
    - auto-saves transcript to ~/Downloads (disable via --no-save)
  - diarize: offline speaker diarization via Senko (prints segments; optional JSON output)
- requirements.txt: minimal core deps (rich, faster-whisper, SpeechRecognition, pyaudio)
- README.md: updated install/usage for macOS & Windows, optional GPU, RealtimeSTT/Senko notes

Why
- Lower latency and better robustness for live terminal transcription (RealtimeSTT)
- Keep a very simple UX, cross-platform
- Optional, very fast speaker diarization flow (Senko)

Install
```bash
python -m venv .venv && source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
pip install -r requirements.txt
# Optional live: best experience
pip install RealtimeSTT
# Optional diarization (Senko)
uv pip install "git+https://github.com/narcotic-sh/senko.git"  # mac/CPU; see Senko README for NVIDIA options
```

Usage
- Live (default engine: RealtimeSTT)
```bash
python transcribe.py live --language en
```
If RealtimeSTT is not present, falls back to legacy automatically.

- Live with legacy
```bash
python transcribe.py live --engine legacy --language en --buffer-size 2 --phrase-time-limit 3
```

- Diarize (WAV 16kHz mono 16-bit)
```bash
python transcribe.py diarize path/to/audio.wav --device auto --json-out diarization.json
```
Prints speaker segments and optionally writes merged segments to JSON.

Notes
- GPU optional; RealtimeSTT supports CUDA. faster-whisper defaults to CPU.
- Windows/macOS supported. PyAudio/PortAudio setup instructions included.
- Transcript auto-save to ~/Downloads; disable with --no-save.

Validation
- Manual smoke on both engines (where available):
  - live (rstt) prints phrase-level outputs, exits cleanly on CTRL+C, writes transcript to Downloads.
  - live (legacy) buffers phrases and prints combined text.
  - diarize prints segments and supports JSON output path.

This is a Droid-assisted PR. Feedback welcome; happy to adjust flags or defaults (e.g., model/language).

---
**Factory Session:** https://app.factory.ai/sessions/670NIP3Svo66NOZTkNwJ (created by Tristan.mcinnis@gmail.com)